### PR TITLE
channel.msg to channel.send (Cinch deprecation 2.2.0)

### DIFF
--- a/lib/logstash/outputs/irc.rb
+++ b/lib/logstash/outputs/irc.rb
@@ -79,9 +79,9 @@ class LogStash::Outputs::Irc < LogStash::Outputs::Base
     text = event.sprintf(@format)
     @bot.channels.each do |channel|
       @logger.debug("Sending to...", :channel => channel, :text => text)
-      channel.msg(pre_string) if !@pre_string.nil?
-      channel.msg(text)
-      channel.msg(post_string) if !@post_string.nil?
+      channel.send(pre_string) if !@pre_string.nil?
+      channel.send(text)
+      channel.send(post_string) if !@post_string.nil?
     end # channels.each
   end # def receive
 end # class LogStash::Outputs::Irc


### PR DESCRIPTION
issue #2 
Deprecation warning: Beginning with version 2.2.0, Channel#msg should not be used anymore. Use Channel#send instead.

``` rubby
  # @note The aliases `msg` and `privmsg` are deprecated and will be
    #   removed in a future version.
    def send(text, notice = false)
      # TODO deprecate 'notice' argument
      text = text.to_s
      if @modes["c"]
        # Remove all formatting and colors if the channel doesn't
        # allow colors.
        text = Cinch::Formatting.unformat(text)
      end
      super(text, notice)
    end
    alias_method :msg, :send # deprecated
    alias_method :privmsg, :send # deprecated
    undef_method(:msg) # yardoc hack
    undef_method(:privmsg) # yardoc hack

    # @deprecated
    def msg(*args)
      Cinch::Utilities::Deprecation.print_deprecation("2.2.0", "Channel#msg", "Channel#send")
      send(*args)
    end

    # @deprecated
    def privmsg(*args)
      Cinch::Utilities::Deprecation.print_deprecation("2.2.0", "Channel#privmsg", "Channel#send")
      send(*args)
    end

    # @return [Fixnum]
    def hash
      @name.hash
    end
```
