### PR TITLE
Allow to send events as announce to the channel

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -36,6 +36,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-messages_per_second>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-nick>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-notice>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-post_string>> |<<string,string>>|No
@@ -95,6 +96,14 @@ Limit the rate of messages sent to IRC in messages per second.
 
 IRC Nickname
 
+[id="plugins-{type}s-{plugin}-notice"]
+===== `notice` 
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Set this to true to send messages as a notice.
+
 [id="plugins-{type}s-{plugin}-password"]
 ===== `password` 
 
@@ -142,6 +151,7 @@ IRC Real name
   * Default value is `false`
 
 Set this to true to enable SSL.
+
 
 [id="plugins-{type}s-{plugin}-user"]
 ===== `user` 

--- a/lib/logstash/outputs/irc.rb
+++ b/lib/logstash/outputs/irc.rb
@@ -48,6 +48,9 @@ class LogStash::Outputs::Irc < LogStash::Outputs::Base
   # Static string after event
   config :post_string, :validate => :string, :required => false
 
+  # Set this to true to send messages as notice
+  config :notice, :validate => :boolean, :default => false
+
   public
 
   def inject_bot(bot)
@@ -90,9 +93,9 @@ class LogStash::Outputs::Irc < LogStash::Outputs::Base
 
     @bot.channels.each do |channel|
       @logger.debug("Sending to...", :channel => channel, :text => text)
-      channel.msg(pre_string) if !@pre_string.nil?
-      channel.msg(text)
-      channel.msg(post_string) if !@post_string.nil?
+      channel.msg(pre_string, :notice => @notice) if !@pre_string.nil?
+      channel.msg(text, :notice => @notice)
+      channel.msg(post_string, :notice => @notice) if !@post_string.nil?
     end # channels.each
   end # def receive
 end # class LogStash::Outputs::Irc

--- a/spec/outputs/irc_spec.rb
+++ b/spec/outputs/irc_spec.rb
@@ -31,7 +31,7 @@ describe LogStash::Outputs::Irc do
     end
 
     it "sends the generated event to the irc" do
-      expect(channel).to receive(:msg).with("This is a message!")
+      expect(channel).to receive(:msg).with("This is a message!", :notice=>false)
       subject.receive(event)
     end
 


### PR DESCRIPTION
This PR introduces the option to send events as notice in `logstash-output-irc`. 
The default remains sending as messages.
